### PR TITLE
Fix error logging bug in encryption setup

### DIFF
--- a/handler/historyHandler.js
+++ b/handler/historyHandler.js
@@ -29,7 +29,7 @@ async function generateSalt(providedSalt) {
     }
     return true;
   } catch (err) {
-    console.error("Error deriving key:", error);
+    console.error("Error deriving key:", err);
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- fix variable name in `generateSalt` error handling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846f1514e548328841a73dfa42b50e0