### PR TITLE
Remove .env from public resources

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,8 +27,7 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "views/html/warning.html",
-        ".env"
+        "views/html/warning.html"
       ],
       "matches": [
         "<all_urls>"


### PR DESCRIPTION
## Summary
- stop exposing `.env` via `web_accessible_resources`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846f5e35b8c8328bd93cc13f1d3066b